### PR TITLE
Integrate invoice v2 backend orchestrator into frontend

### DIFF
--- a/src/services/invoice/invoice.service.js
+++ b/src/services/invoice/invoice.service.js
@@ -1,34 +1,186 @@
-import { getFunctions, httpsCallable } from "firebase/functions";
-import { functions } from "../../firebase/firebaseconfig";
+import { httpsCallable } from "firebase/functions";
+import { collection, doc, getDoc, getDocs, limit, query, where } from "firebase/firestore";
+import { nanoid } from "nanoid";
+import { functions, db } from "../../firebase/firebaseconfig";
 
-const handleInvoice = httpsCallable(functions, "handleInvoiceRequest");
-export async function submitInvoice({
+const createInvoiceCallable = httpsCallable(functions, "createInvoiceV2");
+
+const DEFAULT_POLL_INTERVAL_MS = 700;
+const DEFAULT_TIMEOUT_MS = 45000;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const normalizeUser = (user) => {
+    if (!user) return null;
+    const businessId = user.businessID || user.businessId || user.business?.id || user.business?.businessID || null;
+    return {
+        uid: user.uid,
+        businessID: businessId,
+    };
+};
+
+const normalizeNcf = ({ taxReceiptEnabled, ncfType, ncf }) => {
+    const enabled = Boolean(taxReceiptEnabled || (ncf && ncf.enabled));
+    const type = ncf?.type || ncfType || null;
+    if (!enabled) {
+        return { enabled: false, type: null };
+    }
+    return { enabled: true, type };
+};
+
+export const generateIdempotencyKey = () => nanoid(21);
+
+export const buildInvoiceRequestPayload = ({
     user,
+    userId,
+    business,
+    businessId,
     cart,
     client,
-    accountsReceivable = [],
-    insuranceAR = null,
-    insuranceAuth = null,
-    ncfType = null,
-    taxReceiptEnabled = false,
-    dueDate = null,
-    insuranceEnabled = false
-}) {
-    // Validar que el usuario y el carrito no sean nulos
-    if (!user || !cart) {
-        throw new Error("Se requieren los campos `user` y `cart`");
+    accountsReceivable,
+    insuranceAR,
+    insuranceAuth,
+    insuranceEnabled,
+    taxReceiptEnabled,
+    ncfType,
+    ncf,
+    dueDate,
+    invoiceComment,
+    insurance,
+    preorder,
+    idempotencyKey,
+    isTestMode,
+}) => {
+    const normalizedUser = normalizeUser(user);
+    const resolvedBusinessId = businessId
+        || business?.id
+        || business?.businessID
+        || normalizedUser?.businessID
+        || null;
+    const resolvedUserId = userId || normalizedUser?.uid || null;
+
+    const payload = {
+        idempotencyKey,
+        businessId: resolvedBusinessId,
+        userId: resolvedUserId,
+        cart: cart ?? null,
+        client: client ?? null,
+        accountsReceivable: accountsReceivable ?? null,
+        insuranceAR: insuranceAR ?? null,
+        insuranceAuth: insuranceAuth ?? null,
+        insuranceEnabled: Boolean(insuranceEnabled),
+        taxReceiptEnabled: Boolean(taxReceiptEnabled),
+        ncfType: ncfType ?? null,
+        dueDate: typeof dueDate === "number" ? dueDate : dueDate ? Number(dueDate) : null,
+        invoiceComment: invoiceComment ?? null,
+        insurance: insurance ?? {
+            enabled: Boolean(insuranceEnabled),
+            AR: insuranceAR ?? null,
+            auth: insuranceAuth ?? null,
+        },
+        preorder: preorder ?? (cart?.preorderDetails ? { ...cart.preorderDetails } : undefined),
+        ncf: normalizeNcf({ taxReceiptEnabled, ncfType, ncf }),
+        isTestMode: Boolean(isTestMode),
+    };
+
+    if (normalizedUser) {
+        payload.user = normalizedUser;
     }
 
-    // Validar tipos de taxReceipt
-    if (taxReceiptEnabled && (typeof ncfType !== 'string' || !ncfType.trim())) {
-        throw new Error("`ncfType` inválido cuando `taxReceiptEnabled=true`");
+    if (!payload.businessId) {
+        throw new Error("businessId es requerido para iniciar la factura");
     }
-    try {
-        const { data } = await handleInvoice({ user, cart, client, accountsReceivable, insuranceAR, insuranceAuth, ncfType, taxReceiptEnabled, dueDate, insuranceEnabled });
-    
-        return data;
 
-    } catch (err) {
-        throw err;
+    if (!payload.userId) {
+        throw new Error("userId es requerido para iniciar la factura");
     }
-}
+
+    return payload;
+};
+
+export const submitInvoice = async (params) => {
+    const idempotencyKey = params?.idempotencyKey || generateIdempotencyKey();
+    const payload = buildInvoiceRequestPayload({ ...params, idempotencyKey });
+
+    const { data } = await createInvoiceCallable(payload);
+
+    return {
+        ...data,
+        idempotencyKey,
+        businessId: payload.businessId,
+        userId: payload.userId,
+    };
+};
+
+const fetchFailedTask = async ({ businessId, invoiceId }) => {
+    const outboxRef = collection(db, `businesses/${businessId}/invoicesV2/${invoiceId}/outbox`);
+    const failedQuery = query(outboxRef, where("status", "==", "failed"), limit(1));
+    const failedSnap = await getDocs(failedQuery);
+    if (failedSnap.empty) return null;
+    const docSnap = failedSnap.docs[0];
+    return { id: docSnap.id, ...docSnap.data() };
+};
+
+export const waitForInvoiceResult = async ({
+    businessId,
+    invoiceId,
+    signal,
+    pollInterval = DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+}) => {
+    if (!businessId) {
+        throw new Error("businessId es requerido para consultar la factura");
+    }
+    if (!invoiceId) {
+        throw new Error("invoiceId es requerido para consultar la factura");
+    }
+
+    const invoiceRef = doc(db, `businesses/${businessId}/invoicesV2/${invoiceId}`);
+    const canonicalRef = doc(db, `businesses/${businessId}/invoices/${invoiceId}`);
+
+    const startedAt = Date.now();
+    let lastSnapshot = null;
+
+    while (true) {
+        if (signal?.aborted) {
+            throw new DOMException("La consulta de factura fue cancelada", "AbortError");
+        }
+
+        const invoiceSnap = await getDoc(invoiceRef);
+        const invoiceData = invoiceSnap.exists() ? invoiceSnap.data() : null;
+        if (invoiceData) {
+            lastSnapshot = invoiceData;
+            if (invoiceData.status === "failed") {
+                const failedTask = await fetchFailedTask({ businessId, invoiceId });
+                const errorMessage = failedTask?.lastError
+                    || (failedTask?.type ? `La tarea ${failedTask.type} falló durante el procesamiento.` : "El proceso de factura falló.");
+                const error = new Error(errorMessage);
+                error.code = "invoice-failed";
+                error.invoice = invoiceData;
+                error.failedTask = failedTask;
+                throw error;
+            }
+
+            if (invoiceData.status === "committed") {
+                const canonicalSnap = await getDoc(canonicalRef);
+                if (canonicalSnap.exists()) {
+                    const canonicalData = canonicalSnap.data();
+                    return {
+                        invoice: canonicalData?.data ?? null,
+                        canonical: canonicalData ?? null,
+                        invoiceMeta: invoiceData,
+                    };
+                }
+            }
+        }
+
+        if (Date.now() - startedAt >= timeoutMs) {
+            const timeoutError = new Error("Tiempo de espera agotado al confirmar la factura. Verifica el estado en el historial de facturación.");
+            timeoutError.code = "invoice-timeout";
+            timeoutError.invoice = lastSnapshot;
+            throw timeoutError;
+        }
+
+        await delay(pollInterval);
+    }
+};

--- a/src/services/invoice/useInvoice.js
+++ b/src/services/invoice/useInvoice.js
@@ -1,9 +1,62 @@
-import { useState } from "react";
-import { submitInvoice } from "./invoice.service";
+import { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
 import { getCashCountStrategy } from "../../notification/cashCountNotification/cashCountNotificacion";
-import { FunctionsError } from "firebase/functions";
+import { submitInvoice, waitForInvoiceResult } from "./invoice.service";
+import { GenericClient } from "../../features/clientCart/clientCartSlice";
 
+const simulateDelay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const buildTestModeInvoice = async ({
+    cart,
+    client,
+    taxReceiptEnabled,
+    ncfType,
+    dueDate,
+    invoiceComment,
+}) => {
+    const now = Date.now();
+    const mockNcfCode = taxReceiptEnabled ? `TEST-${ncfType || "NCF"}-${now}` : null;
+    const mockClient = client && client.id ? client : GenericClient;
+
+    const invoice = {
+        ...cart,
+        id: cart?.id || `TEST-INVOICE-${now}`,
+        NCF: mockNcfCode,
+        client: mockClient,
+        cashCountId: "test-cash-count-id",
+        createdAt: new Date(now).toISOString(),
+        status: "test-preview",
+        timestamp: now,
+        testMode: true,
+    };
+
+    if (dueDate) {
+        invoice.dueDate = new Date(dueDate);
+        invoice.hasDueDate = true;
+    }
+
+    if (invoiceComment) {
+        invoice.invoiceComment = invoiceComment;
+    }
+
+    await simulateDelay(600);
+
+    return {
+        invoice,
+        invoiceId: invoice.id,
+    };
+};
+
+const extractCashCountState = (err) => {
+    if (!err) return null;
+    const segments = [err.message, typeof err.details === "string" ? err.details : null]
+        .filter(Boolean)
+        .join(" ");
+    const match = segments.match(/cashCount-(none|closing|closed)/);
+    if (!match) return null;
+    const [, state] = match[0].split("-");
+    return state || "none";
+};
 
 export default function useInvoice() {
     const [loading, setLoading] = useState(false);
@@ -11,65 +64,60 @@ export default function useInvoice() {
 
     const dispatch = useDispatch();
 
-    const processInvoice = async ({
-        user,
-        cart,
-        client,
-        accountsReceivable = [],
-        insuranceAR = null,
-        insuranceAuth = null,
-        ncfType = null,
-        taxReceiptEnabled = false,
-        dueDate = null,
-        insuranceEnabled = false,
-    }) => {
+    const processInvoice = useCallback(async (params) => {
         setLoading(true);
         setError(null);
-
         try {
-            
-            // const invoiceData = await submitInvoice({
-            //     user,
-            //     cart,
-            //     client,
-            //     accountsReceivable,
-            //     insuranceAR,
-            //     insuranceAuth,
-            //     ncfType,
-            //     taxReceiptEnabled,
-            //     dueDate,
-            //     insuranceEnabled
-            // });
-            // return invoiceData;
-        } catch (err) {
-            setError(err);
-
-            const errorMessage = err.message;
-            const errorCode = err.code;
-            const errorDetails = err.details;
-
-            if (["cashCount-none", "cashCount-closed", "cashCount-closing"].includes(errorMessage)) {
-                const cashCountState = errorMessage.split("-")[1];
-                const cashCountStrategy = getCashCountStrategy(cashCountState, dispatch);
-                cashCountStrategy.handleConfirm();
-                return;
-            }else{
-                console.error("Invoice processing error:", {
-                    code: errorCode,
-                    message: errorMessage,
-                    details: errorDetails
-                });
+            if (params?.isTestMode) {
+                const testResult = await buildTestModeInvoice(params);
+                return {
+                    invoice: testResult.invoice,
+                    invoiceId: testResult.invoiceId,
+                    invoiceMeta: { status: "test-preview", testMode: true },
+                    status: "test-preview",
+                    reused: false,
+                    idempotencyKey: null,
+                };
             }
 
-            return;
+            const { signal, ...submissionPayload } = params || {};
+            const submission = await submitInvoice(submissionPayload);
+            const result = await waitForInvoiceResult({
+                businessId: submission.businessId,
+                invoiceId: submission.invoiceId,
+                signal,
+            });
+
+            return {
+                invoice: result.invoice,
+                invoiceMeta: result.invoiceMeta,
+                canonical: result.canonical,
+                invoiceId: submission.invoiceId,
+                status: result.invoiceMeta?.status || submission.status || "pending",
+                reused: Boolean(submission.reused),
+                idempotencyKey: submission.idempotencyKey,
+            };
+        } catch (err) {
+            const cashCountState = extractCashCountState(err);
+            if (cashCountState) {
+                const strategy = getCashCountStrategy(cashCountState, dispatch);
+                strategy.handleConfirm();
+                const formattedError = new Error("No se puede procesar la factura sin cuadre de caja");
+                formattedError.code = `cashCount-${cashCountState}`;
+                setError(formattedError);
+                throw formattedError;
+            }
+
+            setError(err);
+            throw err;
         } finally {
             setLoading(false);
         }
-    }
+    }, [dispatch]);
 
     return {
         loading,
         error,
-        processInvoice
-    }
+        processInvoice,
+    };
 }

--- a/src/views/component/cart/components/InvoicePanel/InvoicePanel.jsx
+++ b/src/views/component/cart/components/InvoicePanel/InvoicePanel.jsx
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 import { Body } from './components/Body/Body'
 import { Button, notification, Spin, Form, Modal as AntdModal, message } from 'antd'
 import { useDispatch, useSelector } from 'react-redux'
-import { resetCart, SelectCartData, SelectSettingCart, toggleCart, toggleInvoicePanel, toggleInvoicePanelOpen, setPaymentMethod, recalcTotals } from '../../../../../features/cart/cartSlice'
-import { processInvoice } from '../../../../../services/invoice/invoiceService'
+import { resetCart, SelectCartData, SelectSettingCart, toggleCart, toggleInvoicePanel, toggleInvoicePanelOpen, setPaymentMethod } from '../../../../../features/cart/cartSlice'
 import { selectUser } from '../../../../../features/auth/userSlice'
 import { deleteClient, selectClient } from '../../../../../features/clientCart/clientCartSlice'
 import { selectAR } from '../../../../../features/accountsReceivable/accountsReceivableSlice'
@@ -104,7 +103,6 @@ export const InvoicePanel = () => {
     const accountsReceivable = useSelector(selectAR)
     const taxReceiptState = useSelector(selectTaxReceipt);
     const { settings: { taxReceiptEnabled } } = taxReceiptState;
-    const total = cart?.payment?.value;
     const isAddedToReceivables = cart?.isAddedToReceivables;
     const business = useSelector(selectBusinessData) || {};
     const insuranceEnabled = useInsuranceEnabled();
@@ -222,38 +220,34 @@ export const InvoicePanel = () => {
                     ?.map(product => `${product.name}: ${product.comment}`)
                     ?.join('; ');
 
-                const { invoice } = await measure('processInvoice', () => processInvoice({
+                const resolvedBusinessId = business?.id || business?.businessID || user?.businessID;
+                if (!resolvedBusinessId) {
+                    throw new Error('No se encontró el negocio asociado para procesar la factura.');
+                }
+                const invoiceResult = await measure('processInvoice', () => runInvoice({
                     cart,
                     user,
                     client,
                     accountsReceivable,
                     taxReceiptEnabled,
                     ncfType,
-                    dispatch,
                     dueDate,
-                    insuranceEnabled: insuranceEnabled,
-                    insuranceAR: insuranceAR,
+                    insuranceEnabled,
+                    insuranceAR,
                     insuranceAuth,
-                    invoiceComment, // Add comments from products to the invoice
-                    isTestMode, // Pass test mode to service
-                }))
-
-                // const invoice = await runInvoice({
-                //     cart,
-                //     user,
-                //     client,
-                //     accountsReceivable,
-                //     taxReceiptEnabled,
-                //     ncfType,
-                //     dueDate: dueDate?.valueOf(), // Convert to milliseconds
-                //     insuranceEnabled,
-                //     insuranceAR,
-                //     insuranceAuth,
-                // })
+                    invoiceComment, // Comentarios agregados desde los productos
+                    isTestMode,
+                    businessId: resolvedBusinessId,
+                    business,
+                }));
+                const createdInvoice = invoiceResult?.invoice;
+                if (!createdInvoice) {
+                    throw new Error('No se pudo recuperar la factura generada desde el backend.');
+                }
 
                 if (shouldPrintInvoice) {
-                    setInvoice(invoice); // Actualizamos estado primero
-                    await measure('handleInvoicePrinting', () => handleInvoicePrinting(invoice));
+                    setInvoice(createdInvoice); // Actualizamos estado primero
+                    await measure('handleInvoicePrinting', () => handleInvoicePrinting(createdInvoice));
                 }
                 if (!shouldPrintInvoice) {
                     setInvoice({});


### PR DESCRIPTION
## Summary
- update the invoice service to call the v2 createInvoice endpoint, build safe payloads, and wait for outbox processing before returning the canonical invoice
- add a revamped `useInvoice` hook that talks to the new service, simulates test mode locally, and keeps the cash-count warnings from the previous UI flow
- refactor `InvoicePanel` submit handling to rely on the new hook, enforce business context, and reuse the returned invoice for printing/cleanup

## Testing
- npx eslint src/services/invoice/invoice.service.js src/services/invoice/useInvoice.js src/views/component/cart/components/InvoicePanel/InvoicePanel.jsx

------
https://chatgpt.com/codex/tasks/task_e_68c8d8753a6883299dc8fb8391a78cca