### PR TITLE
Prevent duplicate invoice processing attempts

### DIFF
--- a/functions/src/versions/v2/invoice/controllers/createInvoice.controller.js
+++ b/functions/src/versions/v2/invoice/controllers/createInvoice.controller.js
@@ -121,11 +121,17 @@ export const createInvoiceV2 = onCall(async ({data}, context) => {
       idempotencyKey,
     });
 
-    logger.info('createInvoiceV2 completed', { traceId, invoiceId: result.invoiceId, reused: result.alreadyExists });
+    logger.info('createInvoiceV2 completed', {
+      traceId,
+      invoiceId: result.invoiceId,
+      reused: result.alreadyExists,
+      invoiceStatus: result.invoiceStatus ?? null,
+    });
     return {
       status: 'pending',
       invoiceId: result.invoiceId,
       reused: result.alreadyExists,
+      invoiceStatus: result.invoiceStatus ?? null,
     };
   } catch (err) {
     if (err instanceof https.HttpsError) throw err;

--- a/functions/src/versions/v2/invoice/controllers/createInvoiceHttp.controller.js
+++ b/functions/src/versions/v2/invoice/controllers/createInvoiceHttp.controller.js
@@ -99,11 +99,17 @@ export const createInvoiceV2Http = https.onRequest(async (req, res) => {
       idempotencyKey,
     });
 
-    logger.info('createInvoiceV2Http completed', { traceId, invoiceId: result.invoiceId, reused: result.alreadyExists });
+    logger.info('createInvoiceV2Http completed', {
+      traceId,
+      invoiceId: result.invoiceId,
+      reused: result.alreadyExists,
+      invoiceStatus: result.invoiceStatus ?? null,
+    });
     return res.status(200).json({
       status: 'pending',
       invoiceId: result.invoiceId,
       reused: result.alreadyExists,
+      invoiceStatus: result.invoiceStatus ?? null,
     });
   } catch (err) {
     logger.error('Unhandled error in createInvoiceV2Http', { traceId, err });

--- a/functions/src/versions/v2/invoice/services/orchestrator.service.js
+++ b/functions/src/versions/v2/invoice/services/orchestrator.service.js
@@ -17,15 +17,29 @@ export async function createPendingInvoice({ businessId, userId, payload, idempo
 
   const idempotencyRef = getIdempotencyRef(businessId, idempotencyKey);
 
+  let invoiceStatus = null;
+
   const { invoiceId, alreadyExists } = await db.runTransaction(async (tx) => {
     const idemSnap = await tx.get(idempotencyRef);
     if (idemSnap.exists) {
       const data = idemSnap.data();
-      return { invoiceId: data.invoiceId, alreadyExists: true };
+      const existingInvoiceId = data.invoiceId;
+      if (existingInvoiceId) {
+        try {
+          const existingInvoiceRef = db.doc(`businesses/${businessId}/invoicesV2/${existingInvoiceId}`);
+          const existingInvoiceSnap = await tx.get(existingInvoiceRef);
+          if (existingInvoiceSnap.exists) {
+            invoiceStatus = existingInvoiceSnap.data()?.status || null;
+          }
+        } catch {}
+      }
+      return { invoiceId: existingInvoiceId, alreadyExists: true };
     }
 
     const newInvoiceId = nanoid();
     const invoiceRef = db.doc(`businesses/${businessId}/invoicesV2/${newInvoiceId}`);
+
+    invoiceStatus = 'pending';
 
     // Derivar dueDate si no llega y hay configuración en billing
     const billing = payload?.cart?.billing || {};
@@ -326,7 +340,7 @@ export async function createPendingInvoice({ businessId, userId, payload, idempo
     return { invoiceId: newInvoiceId, alreadyExists: false };
   });
 
-  return { invoiceId, status: 'pending', alreadyExists };
+  return { invoiceId, status: 'pending', alreadyExists, invoiceStatus };
 }
 
 

--- a/src/services/invoice/useInvoice.js
+++ b/src/services/invoice/useInvoice.js
@@ -6,6 +6,8 @@ import { GenericClient } from "../../features/clientCart/clientCartSlice";
 
 const simulateDelay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+export const DUPLICATE_INVOICE_ERROR_CODE = "invoice-duplicate";
+
 const buildTestModeInvoice = async ({
   cart,
   client,
@@ -116,6 +118,18 @@ export default function useInvoice() {
         const { signal, ...submissionPayload } = params || {};
         
         submission = await submitInvoice(submissionPayload);
+
+        if (submission?.reused) {
+          const duplicateError = new Error(
+            "La factura ya fue generada previamente para este comprobante."
+          );
+          duplicateError.code = DUPLICATE_INVOICE_ERROR_CODE;
+          duplicateError.invoiceId = submission.invoiceId;
+          duplicateError.idempotencyKey = submission.idempotencyKey;
+          duplicateError.invoiceStatus = submission.invoiceStatus || submission.status || null;
+          duplicateError.reused = true;
+          throw duplicateError;
+        }
 
         const result = await waitForInvoiceResult({
           businessId: submission.businessId,

--- a/src/views/component/cart/components/InvoicePanel/InvoicePanel.jsx
+++ b/src/views/component/cart/components/InvoicePanel/InvoicePanel.jsx
@@ -16,7 +16,7 @@ import dayjs from 'dayjs'
 import useInsuranceEnabled from '../../../../../hooks/useInsuranceEnabled'
 import { selectInsuranceAR } from '../../../../../features/insurance/insuranceAccountsReceivableSlice'
 import { selectInsuranceAuthData, clearAuthData } from '../../../../../features/insurance/insuranceAuthSlice'
-import useInvoice from '../../../../../services/invoice/useInvoice'
+import useInvoice, { DUPLICATE_INVOICE_ERROR_CODE } from '../../../../../services/invoice/useInvoice'
 import { selectBusinessData } from '../../../../../features/auth/businessSlice'
 import { downloadInvoiceLetterPdf } from '../../../../../firebase/quotation/downloadQuotationPDF'
 import { selectAppMode } from '../../../../../features/appModes/appModeSlice'
@@ -277,20 +277,47 @@ export const InvoicePanel = () => {
                 }
 
             } catch (error) {
-                notification.error({
-                    message: 'Error de Proceso',
-                    description: error.message,
-                    duration: 4
-                })
+                const isDuplicate = error?.code === DUPLICATE_INVOICE_ERROR_CODE || error?.reused;
+                const invoiceStatus = (error?.invoiceStatus || error?.invoice?.status || '').toLowerCase();
+
+                if (isDuplicate) {
+                    let duplicateDescription = 'Se detectó que este comprobante ya tiene una factura asociada.';
+                    if (invoiceStatus === 'committed') {
+                        duplicateDescription = 'El comprobante ya fue facturado y se encuentra disponible en el historial.';
+                    } else if (invoiceStatus === 'pending' || invoiceStatus === 'committing') {
+                        duplicateDescription = 'Ya hay un proceso de facturación en curso para este comprobante. Espera a que finalice antes de intentar nuevamente.';
+                    } else if (invoiceStatus === 'failed') {
+                        duplicateDescription = 'El intento previo de facturación fue marcado como fallido. Revisa el historial y genera una nueva factura si es necesario.';
+                    }
+
+                    notification.warning({
+                        message: 'Factura duplicada detectada',
+                        description: duplicateDescription,
+                        duration: 5,
+                    });
+                    console.warn('[InvoicePanel] processInvoice -> duplicate detected', {
+                        message: error?.message,
+                        invoiceId: error?.invoiceId ?? null,
+                        idempotencyKey: error?.idempotencyKey ?? null,
+                        invoiceStatus,
+                    });
+                    setInvoice({});
+                } else {
+                    notification.error({
+                        message: 'Error de Proceso',
+                        description: error.message,
+                        duration: 4
+                    })
+                    console.error('[InvoicePanel] processInvoice -> failed', {
+                        message: error?.message,
+                        code: error?.code,
+                        invoiceId: error?.invoiceId ?? error?.invoice?.id ?? null,
+                        idempotencyKey: error?.idempotencyKey ?? null,
+                        reused: error?.reused ?? null,
+                    }, error)
+                }
                 setLoading({ status: false, message: '' })
                 setSubmitted(false)
-                console.error('[InvoicePanel] processInvoice -> failed', {
-                    message: error?.message,
-                    code: error?.code,
-                    invoiceId: error?.invoiceId ?? error?.invoice?.id ?? null,
-                    idempotencyKey: error?.idempotencyKey ?? null,
-                    reused: error?.reused ?? null,
-                }, error)
                 // En caso de error liberamos el bloqueo para que el usuario pueda cambiar el comprobante
                 dispatch(unlockTaxReceiptType());
             }


### PR DESCRIPTION
## Summary
- capture the persisted status when createPendingInvoice reuses an idempotency record and expose it through the callable and HTTP controllers
- short-circuit duplicate submissions in `useInvoice` with a dedicated error code so the UI can halt redundant processing
- surface a warning in `InvoicePanel` when a duplicated comprobante is detected, guiding the user to the existing invoice instead of reprocessing it

## Testing
- npm run lint *(fails: repository has thousands of pre-existing lint violations across frontend and functions)*

------
https://chatgpt.com/codex/tasks/task_e_68cb878632b08329b032d21c888e02c6